### PR TITLE
Added a .env example file to copy for other team members. Teamates ca…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,45 @@
+# NOTE: DO NOT ADD YOUR KEYS IN THIS EXAMPLE FILE. INSTEAD, Create a COPY of this file and name that file to: ".env"
+
+
+# One way to do so is run: "cp .env.example .env" onto your terminal OR copy and paste on the file from your IDE file explorer, but keep in mind, these comments WILL be on the .env file 
+
+
+# Once that file was created, update the .env file where it has quotes as the values replacing it with your OWN actual API keys inside those quotes. The '.env' is already in the '.gitignore' file so no need to add it there again.
+
+# Example SPOTITFY.... = 'JohnSmith1234567....' but replacing it with your actual key inside
+
+
+# We will use python-decouple to to manage env variables and use it on our API modules that needs those API keys
+
+
+
+# SET UP: 
+
+# Run "pip install python-decouple" to download this library . For MAC, do pip3 if no virtual env is being run
+
+
+# Depending on which files need an API key to be sourced, import this library on the top of the file next to where all your imports are at.
+
+
+# To USE: 
+# Line to be added: "from decouple import Config, Csv"
+# NOTE: Csv() explicitly tells the python-decouple to expect environement variables in a CSV format, which is what the .env file really is.  
+
+
+# Make an instance of Config and use this variable to access your env variables 
+
+# Add this line in your def __init__(self) to load your .env file: "config = Config(Csv())" 
+
+
+
+# Example: Sourcing the "SPOTIFY_CLIENT_ID" API key from the .env file to use: 
+
+# "self.SPOTIFY_CLIENT_ID = config('SPOTIFY_CLIENT_ID')"
+
+
+
+# When everything is created and working, you can delete these comments if please
+
+SPOTIFY_CLIENT_ID = 'DELETE THIS AND ADD YOUR OWN ID KEY HERE'
+SPOTIFY_CLIENT_SECRET = 'DELETE THIS AND ADD YOUR OWN ID KEY HERE'
+YOUTUBE_API_KEY = 'DELETE THIS AND ADD YOUR OWN ID KEY HERE'

--- a/.gitignore
+++ b/.gitignore
@@ -167,4 +167,6 @@ env_setup.txt
 
 -H
 
+.env
+
 

--- a/spotifyAPI.py
+++ b/spotifyAPI.py
@@ -3,6 +3,7 @@ import os
 import time
 from pprint import pprint
 import logging
+from decouple import Config, Csv
 
 
 # Note: Need to make a spotify dev account and create app to be able have access to client id and secret key.
@@ -22,11 +23,15 @@ class Spotify_API:
     TOP_TRACKS_ENDPOINT = 'https://api.spotify.com/v1/artists/{id}/top-tracks'
 
     def __init__(self):
+
+        # Using config library to source keys from .env file
+        config = Config(Csv())
+
         # Spotify Client ID
-        self.SPOTIFY_CLIENT_ID = os.environ['SPOTIFY_CLIENT_ID']
+        self.SPOTIFY_CLIENT_ID = config('SPOTIFY_CLIENT_ID')
 
         # Spotify Secret Client ID
-        self.SPOTIFY_CLIENT_SECRET = os.environ['SPOTIFY_CLIENT_SECRET']
+        self.SPOTIFY_CLIENT_SECRET = config('SPOTIFY_CLIENT_SECRET')
 
         # Access token that is needed for every api call
         self.access_token = None


### PR DESCRIPTION
Added a .env example file to copy for other team members. Teammates can add their api key inside their own copy of the .env file. Also, modified the Spotify API to source the .env file using decouple library as a reference

Issue ref #24 