### PR TITLE
Sending thumbnails and video links to template instead

### DIFF
--- a/app.py
+++ b/app.py
@@ -23,6 +23,8 @@ def get_artist_info_route():
     # Spotify will currently return information for artist's Stage name, followers count, artist image,albums w/images, and top tracks w/images
     spotify_information = get_spotify_artist_info(artist)
 
+    artist_video = singer_video(artist)
+
     # Checking if all information on artist is  not found for both api calls, return no artist found message template, else render template with their information
     if spotify_information is None and returnUser == None: # If we get a None , we should display a no info found on our template.
          return render_template('artist.html', artistName= 'No info found.')
@@ -30,7 +32,7 @@ def get_artist_info_route():
         #  Here we will return all the info that we get to create our Bio
          return render_template('artist.html', artistName= returnUser[0], artistCountry = returnUser[1], artistCity = returnUser[2],
                                 artistGender = returnUser[3],  artistBirth = returnUser[4], artistMusic = returnUser[5],
-                                 spotify_information=spotify_information ) # render our data, and send it to the html file to display.\
+                                 spotify_information=spotify_information, artist_video=artist_video) # render our data, and send it to the html file to display.\
     
     # if returnUser == None:
     #     return render_template('artist.html', artistName='No artist found.')

--- a/app.py
+++ b/app.py
@@ -4,6 +4,8 @@ from artistAPI import main as req_musicbrainz_info
 
 from spotifyAPI import get_spotify_artist_info
 
+from youtube_api import singer_video
+
 app = Flask(__name__)
 
 

--- a/templates/artist.html
+++ b/templates/artist.html
@@ -28,9 +28,9 @@
           {%endfor%}
         </ul>
         
-        <!-- Displaying the five videos -->
+        <!-- Displaying the five thumbnails and video links -->
         {% for video in artist_video %}
-        <h4>{{video.title}}</h4><!--TODO Change the loop and parameters for new thumbnails-->
+        <h4><a href="https://www.youtube.com/watch?v={{video.video_id}}">{{video.title}}</a></h4><!--watch is keyword indicating video to play, ? is seperator, v= is to specify videoId-->
         <iframe width="420" height="315" src="https://www.youtube.com/embed/{{video.video_id}}"></iframe>
         {% endfor %}
         

--- a/templates/artist.html
+++ b/templates/artist.html
@@ -28,11 +28,11 @@
           {%endfor%}
         </ul>
         
-        <!-- Displaying the five thumbnails and video links -->
-        {% for video in artist_video %}
+        <!--Displaying the five thumbnails and their video links in the titles-->
+        {% for video in artist_video %}<!--Looping over the list of dictionaries from API-->
         <h4><a href="https://www.youtube.com/watch?v={{video.video_id}}">{{video.title}}</a></h4><!--watch is keyword indicating video to play, ? is seperator, v= is to specify videoId-->
         <a>
-          <img src="{{video.url}}" height="{{video.height}}", width="{{video.width}}">
+          <img src="{{video.url}}" height="{{video.height}}", width="{{video.width}}"><!--creating the thumbnail using paramters from the API-->
         </a>
         {% endfor %}
         

--- a/templates/artist.html
+++ b/templates/artist.html
@@ -28,6 +28,8 @@
           {%endfor%}
         </ul>
 
+        
+
         <!-- Here we hava a btn that will return our uset to the main page to search again. -->
         <button class="btn waves-effect waves-light">  <a class="return-button" href="/">Return to Main Page</a>
         </button>

--- a/templates/artist.html
+++ b/templates/artist.html
@@ -27,7 +27,12 @@
           <li>{{album.album_name}} <img src="{{album.image}}" /></li>
           {%endfor%}
         </ul>
-
+        
+        <!-- Displaying the five videos -->
+        {% for video in artist_video %}
+        <h4>{{video.title}}</h4>
+        <iframe width="560" height="315" src="https://www.youtube.com/embed/{{video.video_id}}"></iframe>
+        {% endfor %}
         
 
         <!-- Here we hava a btn that will return our uset to the main page to search again. -->

--- a/templates/artist.html
+++ b/templates/artist.html
@@ -31,7 +31,9 @@
         <!-- Displaying the five thumbnails and video links -->
         {% for video in artist_video %}
         <h4><a href="https://www.youtube.com/watch?v={{video.video_id}}">{{video.title}}</a></h4><!--watch is keyword indicating video to play, ? is seperator, v= is to specify videoId-->
-        <iframe width="420" height="315" src="https://www.youtube.com/embed/{{video.video_id}}"></iframe>
+        <a>
+          <img src="{{video.url}}" height="{{video.height}}", width="{{video.width}}">
+        </a>
         {% endfor %}
         
 

--- a/templates/artist.html
+++ b/templates/artist.html
@@ -30,8 +30,8 @@
         
         <!-- Displaying the five videos -->
         {% for video in artist_video %}
-        <h4>{{video.title}}</h4>
-        <iframe width="560" height="315" src="https://www.youtube.com/embed/{{video.video_id}}"></iframe>
+        <h4>{{video.title}}</h4><!--TODO Change the loop and parameters for new thumbnails-->
+        <iframe width="420" height="315" src="https://www.youtube.com/embed/{{video.video_id}}"></iframe>
         {% endfor %}
         
 

--- a/youtube_api.py
+++ b/youtube_api.py
@@ -19,29 +19,23 @@ def singer_video():#category needed here?
             type='video',#string, only retrieves a particular type of resource: channel, playlist, or video
             relevanceLanguage='en',#string
             safeSearch='moderate'#string, could be moderate, strict, or none
-        )#no .execute here?
-        # print(response)
-        # print(search_response)
+        )#no .execute() here?
         response = request.execute()
-        print('---------------------response-----------------------')
-        pprint(response)
+        # print('---------------------response-----------------------')
+        # pprint(response)
         # print('------------------------test2---------------------')
         # test2 = response['items'][0]['snippet'] #drilling down into json
         # pprint(test2)
-        print('-----------------------video_title---------------------')
-        video_title = response['items'][0]['snippet']['title']
-        pprint(video_title)
-        print('-----------------------video_id---------------------')
+        # print('-----------------------video_title---------------------')
+        title = response['items'][0]['snippet']['title']
+        # pprint(title)
+        # print('-----------------------video_id---------------------')
         video_id = response['items'][0]['id']['videoId']#getting video url?
-        pprint(video_id)
+        # pprint(video_id)
+        return {'title:': title, 'video_id': video_id}#send back both parameters to itentify video
 
     except:#refine try-except later
         print('err')
 
 
 singer_video()#TEMPORARY FOR STARTING PROGRAM FOR TESTING
-
-
-
-
-

--- a/youtube_api.py
+++ b/youtube_api.py
@@ -32,10 +32,13 @@ def singer_video(artist):#category needed here?
         five_video_list = []#create empty list to hold the five videos
 
         for item in response.get('items', []):#loop to return the value associated with the key 'items', which is a list of dictionaries. Otherwise returns empty list so it won't crash
-            title = item['snippet']['title']#drilling down to pull out the title and video id, and high thumnail parameters 
+            title = item['snippet']['title']#drilling down to pull out the title and video id, and high thumbnail parameters 
             video_id = item['id']['videoId']
-            high_thumbnail = item['snippet']['thumbnails']['high']#['height']
-            five_video_list.append({'title': title, 'video_id': video_id})#package these two items into another dictionary and add them all to the list 
+            # high_thumbnail = item['snippet']['thumbnails']['high']
+            high_height = item['snippet']['thumbnails']['high']['height']
+            high_url = item['snippet']['thumbnails']['high']['url']
+            high_width = item['snippet']['thumbnails']['high']['width']
+            five_video_list.append({'title': title, 'video_id': video_id, 'height': high_height, 'url': high_url, 'width': high_width})#package these two items into another dictionary and add them all to the list 
         pprint(five_video_list)#for testing
         return five_video_list#send back list of parameters to itentify videos
 

--- a/youtube_api.py
+++ b/youtube_api.py
@@ -6,8 +6,8 @@ api_key = os.environ['YOUTUBE_API_KEY']
 api_name = 'youtube'
 api_version = 'v3'
 
-artist_name = input('Artist name? ')#TEMPORARY INPUT FOR TESTING
-def singer_video():#category needed here?
+# artist_name = input('Artist name? ')#TEMPORARY INPUT FOR TESTING
+def singer_video(artist):#category needed here?
      
     try:
         yt_response = build(api_name, api_version, developerKey=api_key)#build() creates a service object takes api name and api version as arguments
@@ -15,14 +15,14 @@ def singer_video():#category needed here?
             part='snippet',#string, always will be snippet?
             maxResults=5,#unsigned integer
             order='relevance',#string, params are: date, rating, relevance, title, videoCount, or viewCount
-            q=artist_name,#string, q is query term to search for
+            q=artist,#string, q is query term to search for
             type='video',#string, only retrieves a particular type of resource: channel, playlist, or video
             relevanceLanguage='en',#string
             safeSearch='moderate'#string, could be moderate, strict, or none
         )#no .execute() here?
         response = request.execute()#response will bethe json turned into a python dictionary?
         
-        # pprint(response)#for testing
+        pprint(response)#for testing
         
         title = response['items'][0]['snippet']['title']#pulling out the titles of the videos
         
@@ -33,13 +33,13 @@ def singer_video():#category needed here?
 
         for item in response.get('items', []):#loop to return the value associated with the key 'items', which is a list of dictionaries. Otherwise returns empty list so it won't crash
             title = item['snippet']['title']#drilling down to pull out the title and video id parameters 
-            video_id = item['id']['videoId']#
+            video_id = item['id']['videoId']
             five_video_list.append({'title': title, 'video_id': video_id})#package these two items into another dictionary and add them all to the list 
-        pprint(five_video_list)#for testing
+        # pprint(five_video_list)#for testing
         return five_video_list#send back list of parameters to itentify videos
 
     except:#refine try-except later
         print('err')
 
-
-singer_video()#TEMPORARY FOR STARTING PROGRAM FOR TESTING
+if __name__ == '__main__':#allows module to be run solo
+    singer_video(input('Artist name? '))

--- a/youtube_api.py
+++ b/youtube_api.py
@@ -13,7 +13,7 @@ def singer_video(artist):#category needed here?
         yt_response = build(api_name, api_version, developerKey=api_key)#build() creates a service object takes api name and api version as arguments
         request = yt_response.search().list(
             part='snippet',#string, always will be snippet?
-            maxResults=5,#unsigned integer
+            maxResults=1,#unsigned integer
             order='relevance',#string, params are: date, rating, relevance, title, videoCount, or viewCount
             q=artist,#string, q is query term to search for
             type='video',#string, only retrieves a particular type of resource: channel, playlist, or video
@@ -32,10 +32,11 @@ def singer_video(artist):#category needed here?
         five_video_list = []#create empty list to hold the five videos
 
         for item in response.get('items', []):#loop to return the value associated with the key 'items', which is a list of dictionaries. Otherwise returns empty list so it won't crash
-            title = item['snippet']['title']#drilling down to pull out the title and video id parameters 
+            title = item['snippet']['title']#drilling down to pull out the title and video id, and high thumnail parameters 
             video_id = item['id']['videoId']
+            high_thumbnail = item['snippet']['thumbnails']['high']#['height']
             five_video_list.append({'title': title, 'video_id': video_id})#package these two items into another dictionary and add them all to the list 
-        # pprint(five_video_list)#for testing
+        pprint(five_video_list)#for testing
         return five_video_list#send back list of parameters to itentify videos
 
     except:#refine try-except later

--- a/youtube_api.py
+++ b/youtube_api.py
@@ -38,7 +38,11 @@ def singer_video(artist):#category needed here?
             high_height = item['snippet']['thumbnails']['high']['height']
             high_url = item['snippet']['thumbnails']['high']['url']
             high_width = item['snippet']['thumbnails']['high']['width']
-            five_video_list.append({'title': title, 'video_id': video_id, 'height': high_height, 'url': high_url, 'width': high_width})#package these two items into another dictionary and add them all to the list 
+            five_video_list.append({'title': title, 
+                                    'video_id': video_id, 
+                                    'height': high_height, 
+                                    'url': high_url, 
+                                    'width': high_width})#package these two items into another dictionary and add them all to the list 
         pprint(five_video_list)#for testing
         return five_video_list#send back list of parameters to itentify videos
 

--- a/youtube_api.py
+++ b/youtube_api.py
@@ -6,44 +6,41 @@ api_key = os.environ['YOUTUBE_API_KEY']
 api_name = 'youtube'
 api_version = 'v3'
 
-# artist_name = input('Artist name? ')#TEMPORARY INPUT FOR TESTING
-def singer_video(artist):#category needed here?
-     
+def singer_video(artist):
     try:
         yt_response = build(api_name, api_version, developerKey=api_key)#build() creates a service object takes api name and api version as arguments
         request = yt_response.search().list(
             part='snippet',#string, always will be snippet?
-            maxResults=1,#unsigned integer
+            maxResults=5,#unsigned integer
             order='relevance',#string, params are: date, rating, relevance, title, videoCount, or viewCount
             q=artist,#string, q is query term to search for
             type='video',#string, only retrieves a particular type of resource: channel, playlist, or video
             relevanceLanguage='en',#string
             safeSearch='moderate'#string, could be moderate, strict, or none
         )#no .execute() here?
-        response = request.execute()#response will bethe json turned into a python dictionary?
+        response = request.execute()#response will be the json turned into a python dictionary?
         
-        pprint(response)#for testing
+        # pprint(response)#FOR (SOLO) TESTING
         
         title = response['items'][0]['snippet']['title']#pulling out the titles of the videos
         
         video_id = response['items'][0]['id']['videoId']#will unique identify videos
         
-        print('---------------')#for testing
+        # print('---------------')#FOR (SOLO) TESTING
         five_video_list = []#create empty list to hold the five videos
 
         for item in response.get('items', []):#loop to return the value associated with the key 'items', which is a list of dictionaries. Otherwise returns empty list so it won't crash
             title = item['snippet']['title']#drilling down to pull out the title and video id, and high thumbnail parameters 
             video_id = item['id']['videoId']
-            # high_thumbnail = item['snippet']['thumbnails']['high']
-            high_height = item['snippet']['thumbnails']['high']['height']
+            high_height = item['snippet']['thumbnails']['high']['height']#could choose betweeen default, high, or medium thumnails, which differ in size and img quality.
             high_url = item['snippet']['thumbnails']['high']['url']
             high_width = item['snippet']['thumbnails']['high']['width']
             five_video_list.append({'title': title, 
                                     'video_id': video_id, 
                                     'height': high_height, 
                                     'url': high_url, 
-                                    'width': high_width})#package these two items into another dictionary and add them all to the list 
-        pprint(five_video_list)#for testing
+                                    'width': high_width})#package these items into dictionaries and add them all to the list 
+        # pprint(five_video_list)#FOR (SOLO) TESTING
         return five_video_list#send back list of parameters to itentify videos
 
     except:#refine try-except later

--- a/youtube_api.py
+++ b/youtube_api.py
@@ -13,26 +13,30 @@ def singer_video():#category needed here?
         yt_response = build(api_name, api_version, developerKey=api_key)#build() creates a service object takes api name and api version as arguments
         request = yt_response.search().list(
             part='snippet',#string, always will be snippet?
-            maxResults=1,#unsigned integer
+            maxResults=5,#unsigned integer
             order='relevance',#string, params are: date, rating, relevance, title, videoCount, or viewCount
             q=artist_name,#string, q is query term to search for
             type='video',#string, only retrieves a particular type of resource: channel, playlist, or video
             relevanceLanguage='en',#string
             safeSearch='moderate'#string, could be moderate, strict, or none
         )#no .execute() here?
-        response = request.execute()
-        # print('---------------------response-----------------------')
-        # pprint(response)
-        # print('------------------------test2---------------------')
-        # test2 = response['items'][0]['snippet'] #drilling down into json
-        # pprint(test2)
-        # print('-----------------------video_title---------------------')
-        title = response['items'][0]['snippet']['title']
-        # pprint(title)
-        # print('-----------------------video_id---------------------')
-        video_id = response['items'][0]['id']['videoId']#getting video url?
-        # pprint(video_id)
-        return {'title:': title, 'video_id': video_id}#send back both parameters to itentify video
+        response = request.execute()#response will bethe json turned into a python dictionary?
+        
+        # pprint(response)#for testing
+        
+        title = response['items'][0]['snippet']['title']#pulling out the titles of the videos
+        
+        video_id = response['items'][0]['id']['videoId']#will unique identify videos
+        
+        print('---------------')#for testing
+        five_video_list = []#create empty list to hold the five videos
+
+        for item in response.get('items', []):#loop to return the value associated with the key 'items', which is a list of dictionaries. Otherwise returns empty list so it won't crash
+            title = item['snippet']['title']#drilling down to pull out the title and video id parameters 
+            video_id = item['id']['videoId']#
+            five_video_list.append({'title': title, 'video_id': video_id})#package these two items into another dictionary and add them all to the list 
+        pprint(five_video_list)#for testing
+        return five_video_list#send back list of parameters to itentify videos
 
     except:#refine try-except later
         print('err')


### PR DESCRIPTION
Changed modules to create thumbnails of the most relevant videos as decided by YouTube. Links to the videos are embedded into the video titles. This is instead of embedding the videos directly on the page. 
Still using the environment variables, as I haven't looked into the changes you made with the .env concept @JSirisavath. 
fixes #22