### PR TITLE
Fixed issue with decouple library is not reading env variables correc…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,32 +9,31 @@
 # Example SPOTITFY.... = 'JohnSmith1234567....' but replacing it with your actual key inside
 
 
-# We will use python-decouple to to manage env variables and use it on our API modules that needs those API keys
+# We will use python-dotenv library to to manage env variables and use it on our API modules that needs those API keys
 
 
 
 # SET UP: 
 
-# Run "pip install python-decouple" to download this library . For MAC, do pip3 if no virtual env is being run
+# Run "pip install python-dotenv" to download this library . For MAC, do pip3 if no virtual env is being run
 
 
 # Depending on which files need an API key to be sourced, import this library on the top of the file next to where all your imports are at.
 
 
 # To USE: 
-# Line to be added: "from decouple import Config, Csv"
-# NOTE: Csv() explicitly tells the python-decouple to expect environement variables in a CSV format, which is what the .env file really is.  
+# Line to be added: "from dotenv import load_dotenv"
+  
 
+# Call "load_dotenv()" in  API module files that need API keys (Usually somewhere before you call your keys for access)
 
-# Make an instance of Config and use this variable to access your env variables 
-
-# Add this line in your def __init__(self) to load your .env file: "config = Config(Csv())" 
+# To referece your keys, add "os.environ.get('EXAMPLE_API_KEY_NAME')" as the value for the  api  variable you be refferencing throughout the module
 
 
 
 # Example: Sourcing the "SPOTIFY_CLIENT_ID" API key from the .env file to use: 
 
-# "self.SPOTIFY_CLIENT_ID = config('SPOTIFY_CLIENT_ID')"
+# "self.SPOTIFY_CLIENT_ID = os.environ.get('SPOTIFY_CLIENT_ID')"
 
 
 

--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,7 @@
 
 
 # To USE: 
+# Line to be added: import os
 # Line to be added: "from dotenv import load_dotenv"
   
 

--- a/spotifyAPI.py
+++ b/spotifyAPI.py
@@ -3,7 +3,7 @@ import os
 import time
 from pprint import pprint
 import logging
-from decouple import Config, Csv
+from dotenv import load_dotenv
 
 
 # Note: Need to make a spotify dev account and create app to be able have access to client id and secret key.
@@ -23,14 +23,13 @@ class Spotify_API:
 
     def __init__(self):
 
-        # Using config library to source keys from .env file
-        config = Config(Csv())
+        load_dotenv()
 
         # Spotify Client ID
-        self.SPOTIFY_CLIENT_ID = config('SPOTIFY_CLIENT_ID')
+        self.SPOTIFY_CLIENT_ID = os.environ.get('SPOTIFY_CLIENT_ID')
 
         # Spotify Secret Client ID
-        self.SPOTIFY_CLIENT_SECRET = config('SPOTIFY_CLIENT_SECRET')
+        self.SPOTIFY_CLIENT_SECRET = os.environ.get('SPOTIFY_CLIENT_SECRET')
 
         # Access token that is needed for every api call
         self.access_token = None

--- a/youtube_api.py
+++ b/youtube_api.py
@@ -1,8 +1,12 @@
 from googleapiclient.discovery import build
 import os
 from pprint import pprint
+from dotenv import load_dotenv
 
-api_key = os.environ['YOUTUBE_API_KEY']
+
+load_dotenv()
+
+api_key = os.environ.get('YOUTUBE_API_KEY')
 api_name = 'youtube'
 api_version = 'v3'
 
@@ -40,7 +44,7 @@ def singer_video(artist):
             # drilling down to pull out the title and video id, and high thumbnail parameters
             title = item['snippet']['title']
             video_id = item['id']['videoId']
-            # could choose betweeen default, high, or medium thumnails, which differ in size and img quality.
+            # could choose between default, high, or medium thumbnails, which differ in size and img quality.
             high_height = item['snippet']['thumbnails']['high']['height']
             high_url = item['snippet']['thumbnails']['high']['url']
             high_width = item['snippet']['thumbnails']['high']['width']
@@ -50,7 +54,7 @@ def singer_video(artist):
                                     'url': high_url,
                                     'width': high_width})  # package these items into dictionaries and add them all to the list
         # pprint(five_video_list)#FOR (SOLO) TESTING
-        return five_video_list  # send back list of parameters to itentify videos
+        return five_video_list  # send back list of parameters to identify videos
 
     except:  # refine try-except later
         print('err')


### PR DESCRIPTION
Fixed issue with decouple library is not reading env variables correctly where it crashed the app. Used a new library called "dotenv" instead and is now working again. Previous library was working before as tested. Apologies! 

Edited the spotify, youtube  API's , and .env example file instructions to cater to this library change. 

Everything should work now. 

Issue  ref:  #41 